### PR TITLE
Fix contact form email link

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,8 +52,7 @@ posts.sort((a, b) => Date.parse(b.data.date) - Date.parse(a.data.date))
       </ul>
       <p>
         En esta web puedes encontrar mis últimos artículos y proyectos. Si
-        quieres contactar conmigo solo tienes que rellenar el siguiente
-        formulario.
+        quieres contactar conmigo solo tienes que escribirme un email a <a href="mailto:fran@franmoreno.com">fran@franmoreno.com</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
This pull request fixes the contact form on the homepage by updating the email link to "fran@franmoreno.com".