### PR TITLE
Reposicionar la web como personal/corporativa

### DIFF
--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -106,9 +106,7 @@ const { class: className } = Astro.props
                   ></path>
                 </svg>
               </div>
-              <div>
-                  Senior React Developer
-              </div>
+              <div>Senior Frontend Developer</div>
             </div>
 
             <div class="flex items-center gap-4 group">

--- a/src/components/MobileMenu.jsx
+++ b/src/components/MobileMenu.jsx
@@ -5,7 +5,6 @@ const navLinks = [
   { href: '/', text: 'Inicio' },
   { href: '/blog', text: 'Blog' },
   { href: '/productos', text: 'Productos' },
-  { href: '/servicios', text: 'Servicios' },
   { href: '/cv', text: 'CV' }
 ]
 

--- a/src/components/footer.astro
+++ b/src/components/footer.astro
@@ -37,10 +37,12 @@ const socialLinks = [
 const links = {
   recursos: [
     { name: 'Blog', url: '/blog' },
-    { name: 'CV', url: 'https://cv.franmoreno.com' },
+    { name: 'CV', url: '/cv' },
+    { name: 'Productos', url: '/productos' },
     { name: 'RSS', url: '/rss.xml' }
   ],
   proyectos: [
+    { name: 'Origen Modular', url: 'https://origenmodular.com' },
     { name: 'Torneos Poker Live', url: 'https://torneospokerlive.com' },
     { name: 'Reloj de Poker', url: 'https://reloj.torneospokerlive.com' },
     { name: 'Sozpic', url: 'https://www.sozpic.com' },

--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -56,17 +56,6 @@ import { Image } from 'astro:assets'
           <li>
             <a
               class="font-semibold hover:text-gray-600 dark:hover:text-gray-300 transition-colors relative group"
-              href="/servicios"
-            >
-              Servicios
-              <span
-                class="absolute -bottom-1 left-0 w-0 h-0.5 bg-current transition-all group-hover:w-full"
-              ></span>
-            </a>
-          </li>
-          <li>
-            <a
-              class="font-semibold hover:text-gray-600 dark:hover:text-gray-300 transition-colors relative group"
               href="/cv"
             >
               CV

--- a/src/data/resume.ts
+++ b/src/data/resume.ts
@@ -43,6 +43,16 @@ export const RESUME_DATA = {
   ],
   work: [
     {
+      company: 'Knowmad Mood',
+      link: 'https://www.knowmadmood.com',
+      badges: ['Remote', 'React', 'TypeScript'],
+      title: 'Senior Frontend Developer',
+      start: '2026',
+      end: '',
+      description:
+        'Desarrollador Frontend Senior en Knowmad Mood, trabajando en remoto sobre proyectos web con React, TypeScript y Next.js. Participo en el desarrollo de aplicaciones, la definición de componentes reutilizables y las decisiones técnicas del frontend, colaborando con equipos multidisciplinares.'
+    },
+    {
       company: 'Minery Report',
       link: 'https://www.mineryreport.com',
       badges: ['Remote', 'React', 'TypeScript'],
@@ -177,8 +187,8 @@ export const RESUME_DATA = {
       techStack: ['React', 'Tailwind CSS', 'Next.js', 'Supabase'],
       description: 'Web de la empresa ResGes',
       link: {
-        label: 'resges.com',
-        href: 'https://resges.com/'
+        label: 'resges.es',
+        href: 'https://resges.es/'
       }
     }
   ]

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,21 +4,17 @@ import Project from '../components/project.astro'
 import Post from '../components/post.astro'
 import Stack from '../components/stack.astro'
 import HeroSection from '../components/HeroSection.astro'
-import CalendarScript from '../components/CalendarScript.astro'
-import { Image } from 'astro:assets'
 
 import { getCollection } from 'astro:content'
-import { getFeaturedProducts } from '../data/products'
 
 const posts = await getCollection('blog')
-const featuredProducts = getFeaturedProducts()
 
 posts.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime())
 ---
 
 <Layout
   title="Fran Moreno — Desarrollador Web Frontend (React, Next.js, Astro)"
-  description="Soy Fran Moreno, ingeniero informático y desarrollador web frontend con más de 15 años de experiencia. Especializado en React, Next.js, Astro y Cloudflare. Blog, proyectos y servicios de consultoría."
+  description="Soy Fran Moreno, ingeniero informático y desarrollador web frontend con más de 15 años de experiencia. Especializado en React, Next.js, Astro y Cloudflare. Blog, proyectos y CV."
 >
   <HeroSection />
 
@@ -188,134 +184,6 @@ posts.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime())
     </div>
   </div>
 
-  <!-- Productos Destacados Section -->
-  <div
-    class="mx-auto max-w-7xl px-6 lg:px-8 py-16 sm:py-24 bg-gray-50 dark:bg-gray-900/50"
-  >
-    <div class="mx-auto max-w-2xl lg:max-w-none">
-      <div class="space-y-4">
-        <div
-          class="flex flex-col md:flex-row items-start md:items-center justify-between"
-        >
-          <h2 class="text-3xl font-bold tracking-tight sm:text-4xl">
-            Productos Digitales
-          </h2>
-          <a
-            href="/productos"
-            class="text-sm font-semibold leading-6 text-indigo-600 dark:text-indigo-300 hover:text-indigo-500 dark:hover:text-indigo-200 transition-colors"
-          >
-            Ver todos <span aria-hidden="true">→</span>
-          </a>
-        </div>
-        <p class="text-lg text-gray-600 dark:text-gray-300">
-          Herramientas y recursos digitales para mejorar tu productividad y
-          organización personal.
-        </p>
-      </div>
-
-      <div class="mt-10">
-        <div class="space-y-8">
-          {
-            featuredProducts.map((product, index) => (
-              <div class="relative overflow-hidden rounded-2xl bg-white dark:bg-gray-800 shadow-lg ring-1 ring-gray-200 dark:ring-gray-700 p-8">
-                <div class="absolute top-4 right-4 z-10">
-                  <span class="inline-flex items-center rounded-full bg-indigo-600 px-3 py-1 text-xs font-medium text-white">
-                    {product.price === 'Gratis' ? 'Gratis' : 'Nuevo'}
-                  </span>
-                </div>
-
-                <div class="grid gap-8 lg:grid-cols-2 lg:gap-12">
-                  <div>
-                    <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">
-                      {product.title}
-                    </h3>
-                    <p class="text-gray-600 dark:text-gray-300 mb-6">
-                      {product.description}
-                    </p>
-
-                    <div class="space-y-3 mb-6">
-                      {product.features.slice(0, 3).map((feature) => (
-                        <div class="flex items-center text-sm text-gray-600 dark:text-gray-300">
-                          <svg
-                            class="h-4 w-4 text-indigo-600 dark:text-indigo-400 mr-2"
-                            fill="currentColor"
-                            viewBox="0 0 20 20"
-                          >
-                            <path
-                              fill-rule="evenodd"
-                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                              clip-rule="evenodd"
-                            />
-                          </svg>
-                          {feature}
-                        </div>
-                      ))}
-                    </div>
-
-                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                      <div class="flex items-center gap-4">
-                        <span class="text-3xl font-bold text-gray-900 dark:text-white">
-                          {product.price}
-                        </span>
-                        <div class="flex flex-wrap gap-2">
-                          {product.tags.slice(0, 2).map((tag) => (
-                            <span class="inline-flex items-center rounded-md bg-indigo-50 dark:bg-indigo-900/30 px-2 py-1 text-xs font-medium text-indigo-700 dark:text-indigo-300">
-                              {tag}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-
-                      <a
-                        href={product.gumroadUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 transition-colors"
-                      >
-                        {product.price === 'Gratis'
-                          ? 'Probar ahora'
-                          : 'Comprar ahora'}
-                        <svg
-                          class="h-4 w-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                          />
-                        </svg>
-                      </a>
-                    </div>
-                  </div>
-
-                  <div class="relative">
-                    <div class="aspect-[4/3] w-full overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-700">
-                      <Image
-                        src={product.image}
-                        alt={product.title}
-                        class="h-full w-full object-cover object-center"
-                        loading="lazy"
-                        format="webp"
-                        quality={85}
-                        width={400}
-                        height={300}
-                        densities={[1, 2]}
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            ))
-          }
-        </div>
-      </div>
-    </div>
-  </div>
-
   <div class="mx-auto max-w-7xl px-6 lg:px-8 py-16 sm:py-24">
     <div class="mx-auto max-w-2xl lg:max-w-none text-center">
       <h2 class="text-3xl font-bold tracking-tight sm:text-4xl mb-10">
@@ -342,23 +210,24 @@ posts.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime())
                 class="text-center text-xl font-semibold leading-8 text-white sm:text-2xl sm:leading-9"
               >
                 <p class="mb-8">
-                  ¿Necesitas ayuda para mejorar tu proyecto web o formar a tu
-                  equipo técnico?
+                  ¿Buscas ayuda profesional para tu proyecto web?
                 </p>
                 <p>
-                  Agenda una consultoría gratuita y descubre cómo puedo ayudarte
-                  a alcanzar tus objetivos.
+                  Trabajo los proyectos de consultoría y desarrollo desde <strong
+                    class="font-bold">Origen Modular</strong
+                  >.
                 </p>
               </blockquote>
               <div
                 class="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4"
               >
-                <button
-                  data-cal-link="franmoreno/consultoria"
-                  data-cal-config='{"layout":"month_view"}'
+                <a
+                  href="https://origenmodular.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   class="inline-flex items-center gap-2 rounded-full bg-white px-8 py-4 text-base font-semibold text-indigo-600 shadow-sm hover:bg-indigo-50 transition-colors duration-300"
                 >
-                  Agendar reunión gratuita
+                  Ir a Origen Modular
                   <svg
                     class="w-5 h-5"
                     fill="none"
@@ -369,15 +238,15 @@ posts.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime())
                       stroke-linecap="round"
                       stroke-linejoin="round"
                       stroke-width="2"
-                      d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                      d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
                     ></path>
                   </svg>
-                </button>
+                </a>
                 <a
-                  href="/servicios"
+                  href="mailto:fran@franmoreno.com"
                   class="inline-flex items-center gap-2 rounded-full bg-indigo-400/20 backdrop-blur-sm px-8 py-4 text-base font-semibold text-white hover:bg-indigo-400/30 transition-colors duration-300"
                 >
-                  Ver servicios
+                  Escríbeme
                   <svg
                     class="w-5 h-5"
                     fill="none"
@@ -388,7 +257,8 @@ posts.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime())
                       stroke-linecap="round"
                       stroke-linejoin="round"
                       stroke-width="2"
-                      d="M14 5l7 7m0 0l-7 7m7-7H3"></path>
+                      d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                    ></path>
                   </svg>
                 </a>
               </div>
@@ -399,5 +269,3 @@ posts.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime())
     </div>
   </div>
 </Layout>
-
-<CalendarScript />

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -17,7 +17,7 @@ export const GET: APIRoute = async () => {
 
   const body = `# Fran Moreno
 
-> Web personal y blog de Fran Moreno, ingeniero informático y desarrollador web frontend con más de 15 años de experiencia. Especializado en React, Next.js, Astro, TypeScript y el ecosistema Cloudflare. Cofundador de Sozpic y podcaster en "Necesito un Arma".
+> Web personal y blog de Fran Moreno, ingeniero informático y desarrollador web frontend con más de 15 años de experiencia. Especializado en React, Next.js, Astro, TypeScript y el ecosistema Cloudflare. Podcaster en "Necesito un Arma".
 
 Contacto: fran@franmoreno.com
 Ubicación: España
@@ -27,15 +27,15 @@ Idioma principal del contenido: español (es-ES)
 
 - Ingeniero informático.
 - Más de 15 años desarrollando aplicaciones web; foco actual: Frontend con React (Astro y Next.js).
-- Trabaja como freelance a través de su SL Origen Modular.
+- Los servicios de consultoría, desarrollo y formación se ofrecen desde Origen Modular (https://origenmodular.com), no desde esta web. franmoreno.com es su web personal: blog, proyectos y CV.
 - Stack habitual: React, Next.js, Astro, TypeScript, Tailwind CSS, Cloudflare (Pages, Workers, Workers AI, D1).
 - Otros intereses: poker (varios SaaS y herramientas del sector), productividad (GTD), formación a desarrolladores junior.
 
 ## Páginas principales
 
-- [Inicio](${SITE}/): presentación, proyectos destacados, stack y CTA de contacto.
+- [Inicio](${SITE}/): presentación, proyectos destacados, stack y contacto.
 - [Blog](${SITE}/blog): artículos sobre desarrollo web, frameworks, despliegue y experiencias.
-- [Servicios](${SITE}/servicios): servicios de desarrollo, consultoría y formación.
+- [Servicios](${SITE}/servicios): página informativa que redirige a Origen Modular, donde se ofrecen los servicios.
 - [Productos](${SITE}/productos): productos digitales (kits GTD, plantillas, etc.).
 - [CV](${SITE}/cv): trayectoria profesional.
 - [RSS](${SITE}/rss.xml): feed de artículos.
@@ -47,7 +47,8 @@ Idioma principal del contenido: español (es-ES)
 - [Mi Bankroll](https://mibankroll.com): SaaS de gestión de banca para jugadores de poker. Next.js.
 - [PokerReads](https://pokerreads.app): MicroSaaS mobile-first para tomar notas de rivales en poker en vivo, con integración de IA. Next.js + Cloudflare.
 - [ResGes](https://resges.es): SaaS de gestión de gastos y rentabilidad para hostelería, con IA. Next.js.
-- [Sozpic](https://www.sozpic.com): proyecto del que es cofundador.
+- [Origen Modular](https://origenmodular.com): su empresa de consultoría y desarrollo web.
+- [Sozpic](https://www.sozpic.com): empresa de desarrollo web que cofundó (2011-2021).
 
 ## Artículos del blog
 

--- a/src/pages/productos.astro
+++ b/src/pages/productos.astro
@@ -98,18 +98,17 @@ import { products } from '../data/products'
           implementación, no dudes en contactarme. Estoy aquí para ayudarte.
         </p>
         <div class="mt-10 flex items-center justify-center gap-x-6">
-          <button
-            data-cal-link="franmoreno/consultoria"
-            data-cal-config='{"layout":"month_view"}'
+          <a
+            href="mailto:fran@franmoreno.com"
             class="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white transition-colors"
           >
-            Agendar consulta gratuita
-          </button>
+            Escríbeme por email
+          </a>
           <a
-            href="/servicios"
+            href="/blog"
             class="text-sm font-semibold leading-6 text-white hover:text-gray-300 transition-colors"
           >
-            Ver servicios <span aria-hidden="true">→</span>
+            Ver el blog <span aria-hidden="true">→</span>
           </a>
         </div>
       </div>

--- a/src/pages/servicios.astro
+++ b/src/pages/servicios.astro
@@ -1,14 +1,19 @@
 ---
 import Layout from '../layouts/Layout.astro'
-import CalendarScript from '../components/CalendarScript.astro'
+
+const servicios = [
+  'Consultoría técnica y auditoría de arquitectura web',
+  'Desarrollo de aplicaciones web modernas',
+  'Formación y mentoring a equipos técnicos',
+  'Dirección técnica y definición de procesos'
+]
 ---
 
 <Layout
-  title="Servicios de Consultoría Web - Fran Moreno"
-  description="Servicios de consultoría web y desarrollo. Más de 15 años de experiencia ayudando a empresas a mejorar su presencia digital y optimizar sus procesos de desarrollo."
+  title="Servicios — ahora en Origen Modular | Fran Moreno"
+  description="Los servicios de consultoría técnica, desarrollo web y formación que ofrecía como freelance se prestan ahora desde Origen Modular."
   type="services"
 >
-  <!-- Hero Section -->
   <section class="relative overflow-hidden py-16 sm:py-24">
     <div class="absolute inset-0 -z-10">
       <div
@@ -22,426 +27,105 @@ import CalendarScript from '../components/CalendarScript.astro'
     </div>
 
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
-      <div class="mx-auto max-w-2xl lg:max-w-4xl">
-        <div class="text-center">
-          <h1
-            class="text-4xl font-bold tracking-tight sm:text-6xl bg-gradient-to-r from-gray-900 via-gray-800 to-gray-700 dark:from-white dark:via-gray-200 dark:to-gray-300 bg-clip-text text-transparent mb-8"
-          >
-            Consultoría Web & Desarrollo
-          </h1>
-          <p
-            class="mt-6 text-lg leading-8 text-gray-600 dark:text-gray-300 max-w-2xl mx-auto"
-          >
-            Con más de 15 años de experiencia en el desarrollo web y dirección
-            técnica, ayudo a empresas y equipos a mejorar sus procesos de
-            desarrollo y presencia digital a través de soluciones personalizadas
-            y eficientes.
-          </p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Servicios -->
-  <section class="py-16 sm:py-24">
-    <div class="mx-auto max-w-7xl px-6 lg:px-8">
-      <div class="mx-auto max-w-2xl lg:max-w-4xl">
-        <div class="text-center mb-16">
-          <h2
-            class="text-3xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-4xl"
-          >
-            Servicios
-          </h2>
-          <p class="mt-4 text-lg text-gray-600 dark:text-gray-300">
-            Soluciones adaptadas a tus necesidades específicas
-          </p>
-        </div>
-
-        <div class="grid gap-8 lg:grid-cols-2">
-          <!-- Consultoría Técnica -->
-          <div class="group relative">
-            <div
-              class="relative rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-800/50 p-8 transition-all duration-300 hover:border-indigo-500 dark:hover:border-indigo-400 hover:shadow-xl dark:hover:shadow-gray-800/30"
-            >
-              <div class="flex items-center gap-4 mb-6">
-                <div
-                  class="flex-shrink-0 rounded-xl bg-indigo-100 dark:bg-indigo-900/50 p-3"
-                >
-                  <svg
-                    class="w-6 h-6 text-indigo-600 dark:text-indigo-400"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                    ></path>
-                  </svg>
-                </div>
-                <h3 class="text-xl font-semibold text-gray-900 dark:text-white">
-                  Consultoría Técnica
-                </h3>
-              </div>
-              <ul class="space-y-4 text-gray-600 dark:text-gray-300">
-                <li class="flex items-start gap-3">
-                  <svg
-                    class="w-5 h-5 text-indigo-500 dark:text-indigo-400 mt-1 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                  </svg>
-                  <span>Auditoría y optimización de arquitectura web</span>
-                </li>
-                <li class="flex items-start gap-3">
-                  <svg
-                    class="w-5 h-5 text-indigo-500 dark:text-indigo-400 mt-1 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                  </svg>
-                  <span>Mejora de rendimiento y optimización</span>
-                </li>
-                <li class="flex items-start gap-3">
-                  <svg
-                    class="w-5 h-5 text-indigo-500 dark:text-indigo-400 mt-1 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                  </svg>
-                  <span>Asesoramiento en stack tecnológico</span>
-                </li>
-              </ul>
-            </div>
-          </div>
-
-          <!-- Desarrollo Web -->
-          <div class="group relative">
-            <div
-              class="relative rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-800/50 p-8 transition-all duration-300 hover:border-indigo-500 dark:hover:border-indigo-400 hover:shadow-xl dark:hover:shadow-gray-800/30"
-            >
-              <div class="flex items-center gap-4 mb-6">
-                <div
-                  class="flex-shrink-0 rounded-xl bg-indigo-100 dark:bg-indigo-900/50 p-3"
-                >
-                  <svg
-                    class="w-6 h-6 text-indigo-600 dark:text-indigo-400"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
-                  </svg>
-                </div>
-                <h3 class="text-xl font-semibold text-gray-900 dark:text-white">
-                  Desarrollo Web
-                </h3>
-              </div>
-              <ul class="space-y-4 text-gray-600 dark:text-gray-300">
-                <li class="flex items-start gap-3">
-                  <svg
-                    class="w-5 h-5 text-indigo-500 dark:text-indigo-400 mt-1 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                  </svg>
-                  <span>Desarrollo de aplicaciones web modernas</span>
-                </li>
-                <li class="flex items-start gap-3">
-                  <svg
-                    class="w-5 h-5 text-indigo-500 dark:text-indigo-400 mt-1 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                  </svg>
-                  <span>Implementación de arquitecturas escalables</span>
-                </li>
-                <li class="flex items-start gap-3">
-                  <svg
-                    class="w-5 h-5 text-indigo-500 dark:text-indigo-400 mt-1 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                  </svg>
-                  <span>Integración de sistemas y APIs</span>
-                </li>
-              </ul>
-            </div>
-          </div>
-
-          <!-- Formación -->
-          <div class="group relative">
-            <div
-              class="relative rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-800/50 p-8 transition-all duration-300 hover:border-indigo-500 dark:hover:border-indigo-400 hover:shadow-xl dark:hover:shadow-gray-800/30"
-            >
-              <div class="flex items-center gap-4 mb-6">
-                <div
-                  class="flex-shrink-0 rounded-xl bg-indigo-100 dark:bg-indigo-900/50 p-3"
-                >
-                  <svg
-                    class="w-6 h-6 text-indigo-600 dark:text-indigo-400"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-                    ></path>
-                  </svg>
-                </div>
-                <h3 class="text-xl font-semibold text-gray-900 dark:text-white">
-                  Formación y Mentoring
-                </h3>
-              </div>
-              <ul class="space-y-4 text-gray-600 dark:text-gray-300">
-                <li class="flex items-start gap-3">
-                  <svg
-                    class="w-5 h-5 text-indigo-500 dark:text-indigo-400 mt-1 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                  </svg>
-                  <span>Formación a equipos técnicos</span>
-                </li>
-                <li class="flex items-start gap-3">
-                  <svg
-                    class="w-5 h-5 text-indigo-500 dark:text-indigo-400 mt-1 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                  </svg>
-                  <span>Mentoring para desarrolladores</span>
-                </li>
-                <li class="flex items-start gap-3">
-                  <svg
-                    class="w-5 h-5 text-indigo-500 dark:text-indigo-400 mt-1 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                  </svg>
-                  <span>Workshops y sesiones prácticas</span>
-                </li>
-              </ul>
-            </div>
-          </div>
-
-          <!-- Dirección Técnica -->
-          <div class="group relative">
-            <div
-              class="relative rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-800/50 p-8 transition-all duration-300 hover:border-indigo-500 dark:hover:border-indigo-400 hover:shadow-xl dark:hover:shadow-gray-800/30"
-            >
-              <div class="flex items-center gap-4 mb-6">
-                <div
-                  class="flex-shrink-0 rounded-xl bg-indigo-100 dark:bg-indigo-900/50 p-3"
-                >
-                  <svg
-                    class="w-6 h-6 text-indigo-600 dark:text-indigo-400"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-                    ></path>
-                  </svg>
-                </div>
-                <h3 class="text-xl font-semibold text-gray-900 dark:text-white">
-                  Dirección Técnica
-                </h3>
-              </div>
-              <ul class="space-y-4 text-gray-600 dark:text-gray-300">
-                <li class="flex items-start gap-3">
-                  <svg
-                    class="w-5 h-5 text-indigo-500 dark:text-indigo-400 mt-1 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                  </svg>
-                  <span>Gestión y liderazgo de equipos técnicos</span>
-                </li>
-                <li class="flex items-start gap-3">
-                  <svg
-                    class="w-5 h-5 text-indigo-500 dark:text-indigo-400 mt-1 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                  </svg>
-                  <span>Definición de procesos y metodologías</span>
-                </li>
-                <li class="flex items-start gap-3">
-                  <svg
-                    class="w-5 h-5 text-indigo-500 dark:text-indigo-400 mt-1 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                  </svg>
-                  <span>Planificación estratégica de proyectos</span>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- CTA -->
-  <section class="py-16 sm:py-24">
-    <div class="mx-auto max-w-7xl px-6 lg:px-8">
-      <div class="mx-auto max-w-2xl lg:max-w-4xl">
-        <div
-          class="relative overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-500 to-indigo-600 dark:from-indigo-600 dark:to-indigo-700 px-8 py-16 md:px-12 md:py-20 shadow-xl"
+      <div class="mx-auto max-w-2xl lg:max-w-3xl text-center">
+        <p
+          class="text-sm font-semibold uppercase tracking-wider text-indigo-600 dark:text-indigo-300 mb-4"
         >
-          <div
-            class="absolute inset-0 bg-grid-white/10 [mask-image:linear-gradient(0deg,white,rgba(255,255,255,0.6))]"
+          Esta página se ha mudado
+        </p>
+        <h1
+          class="text-4xl font-bold tracking-tight sm:text-5xl bg-gradient-to-r from-gray-900 via-gray-800 to-gray-700 dark:from-white dark:via-gray-200 dark:to-gray-300 bg-clip-text text-transparent mb-8"
+        >
+          Los servicios ahora están en Origen Modular
+        </h1>
+        <p class="text-lg leading-8 text-gray-600 dark:text-gray-300">
+          Esta web es mi espacio personal: el blog, mis proyectos y mi CV. Los
+          trabajos de consultoría técnica, desarrollo web y formación los presto
+          ahora desde <strong class="font-semibold text-gray-900 dark:text-white"
+            >Origen Modular</strong
+          >, donde encontrarás el detalle de servicios, casos y formas de
+          contacto.
+        </p>
+
+        <div
+          class="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4"
+        >
+          <a
+            href="https://origenmodular.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-2 rounded-full bg-indigo-600 px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400 transition-colors duration-300"
           >
-          </div>
-          <div class="relative">
-            <h2
-              class="text-2xl font-bold tracking-tight text-white sm:text-3xl mb-4 text-center"
+            Ver servicios en Origen Modular
+            <svg
+              class="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
             >
-              ¿Necesitas ayuda con tu proyecto?
-            </h2>
-            <p
-              class="text-lg text-indigo-100 mb-12 text-center max-w-2xl mx-auto"
-            >
-              Agenda una reunión de consultoría gratuita para discutir cómo
-              puedo ayudarte a alcanzar tus objetivos técnicos y llevar tu
-              proyecto al siguiente nivel.
-            </p>
-            <div
-              class="flex flex-col sm:flex-row items-center justify-center gap-4"
-            >
-              <button
-                data-cal-link="franmoreno/consultoria"
-                data-cal-config='{"layout":"month_view"}'
-                class="inline-flex items-center gap-2 rounded-full bg-white px-8 py-4 text-base font-semibold text-indigo-600 shadow-sm hover:bg-indigo-50 transition-colors duration-300"
-              >
-                Agendar reunión
-                <svg
-                  class="w-5 h-5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                  ></path>
-                </svg>
-              </button>
-              <span class="text-indigo-100">o</span>
-              <a
-                href="mailto:fran@franmoreno.com"
-                class="inline-flex items-center gap-2 rounded-full bg-indigo-400/20 backdrop-blur-sm px-8 py-4 text-base font-semibold text-white hover:bg-indigo-400/30 transition-colors duration-300"
-              >
-                Contactar por email
-                <svg
-                  class="w-5 h-5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                  ></path>
-                </svg>
-              </a>
-            </div>
-          </div>
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+              ></path>
+            </svg>
+          </a>
+          <a
+            href="mailto:fran@franmoreno.com"
+            class="inline-flex items-center gap-2 rounded-full px-8 py-4 text-base font-semibold text-gray-800 dark:text-gray-200 hover:text-indigo-600 dark:hover:text-indigo-300 transition-colors duration-300"
+          >
+            O escríbeme directamente
+            <span aria-hidden="true">→</span>
+          </a>
         </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="pb-16 sm:pb-24">
+    <div class="mx-auto max-w-7xl px-6 lg:px-8">
+      <div class="mx-auto max-w-2xl lg:max-w-3xl">
+        <div
+          class="rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-800/50 p-8"
+        >
+          <h2
+            class="text-lg font-semibold text-gray-900 dark:text-white mb-6 text-center"
+          >
+            Lo que se ofrece desde Origen Modular
+          </h2>
+          <ul class="space-y-4 text-gray-600 dark:text-gray-300">
+            {
+              servicios.map((servicio) => (
+                <li class="flex items-start gap-3">
+                  <svg
+                    class="w-5 h-5 text-indigo-500 dark:text-indigo-400 mt-0.5 flex-shrink-0"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                  <span>{servicio}</span>
+                </li>
+              ))
+            }
+          </ul>
+        </div>
+
+        <p class="mt-8 text-center text-sm text-gray-500 dark:text-gray-400">
+          ¿Buscabas mi perfil profesional? Está en <a
+            href="/cv"
+            class="font-semibold text-indigo-600 dark:text-indigo-300 hover:underline"
+            >mi CV</a
+          >.
+        </p>
       </div>
     </div>
   </section>
 </Layout>
-
-<CalendarScript />


### PR DESCRIPTION
Los servicios freelance pasan a ofrecerse desde [origenmodular.com](https://origenmodular.com), así que esta web se queda como espacio personal: blog, proyectos, productos y CV.

## Servicios

- `/servicios` se convierte en **página puente** hacia Origen Modular. Se mantiene la ruta por SEO y enlaces antiguos, pero sale del menú (desktop y móvil).
- Se retiran los CTAs de consultoría con Cal.com del home y de `/productos`. El de `/productos` ya estaba muerto: nunca cargaba el script de Cal.
- El CTA del home ahora apunta a Origen Modular y a email.

## Portada

- El bloque de productos destacados sale del home. `/productos` sigue viva y en el menú.
- `llms.txt` aclara la separación entre web personal y Origen Modular, para los crawlers de IA.

## Footer

- El CV apuntaba al subdominio externo `cv.franmoreno.com`; ahora va a `/cv`.
- Añadidos Productos y Origen Modular.

## CV

- Nueva entrada: **Knowmad Mood — Senior Frontend Developer (2026 – Presente)**. Minery Report queda cerrado en 2026.
- El hero pasa de "Senior React Developer" a "Senior Frontend Developer" para no contradecir al CV.
- Corregido el enlace de ResGes (`resges.com` → `resges.es`), que estaba mal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)